### PR TITLE
Remove docker version from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     keywords='pytest-postgres',
 
     install_requires=[
-        'docker==2.5.1',
+        'docker',
         'psycopg2',
         'pytest',
     ],


### PR DESCRIPTION
Is pinning to this version of docker necessary? The test runs fine with docker 3.5.0 for me...