### PR TITLE
Catch and log errors raised by container.kill()

### DIFF
--- a/tests/test_catch_docker_error.py
+++ b/tests/test_catch_docker_error.py
@@ -1,0 +1,22 @@
+from unittest.mock import patch
+
+import pytest
+from docker.errors import APIError
+from pytest_postgres.plugin import catch_docker_error
+
+
+@patch('pytest_postgres.plugin.log')
+def test_catch_docker_error_doesnt_mask_other_errors(fake_log):
+    err = ValueError('not a docker API error!')
+    with pytest.raises(ValueError):
+        with catch_docker_error():
+            raise err
+    fake_log.exception.assert_not_called()
+
+
+@patch('pytest_postgres.plugin.log')
+def test_catch_docker_error(fake_log):
+    err = APIError('oh no!')
+    with catch_docker_error():
+        raise err
+    fake_log.exception.assert_called_with(err)


### PR DESCRIPTION
In the `finally` block, if the container can't be killed (because it's already died with an error, say) then `container.remove()` would not get called. This meant that docker would get cluttered with more and more broken containers from failed test runs.

This change makes it so that docker `APIErrors` are caught and logged but do not block further cleanup.