### PR TITLE
Shorter timeout in check_connection()

### DIFF
--- a/pytest_postgres/plugin.py
+++ b/pytest_postgres/plugin.py
@@ -35,7 +35,7 @@ def docker():
 
 def check_connection(params):
     delay = 0.01
-    for _ in range(20):
+    for _ in range(10):
         try:
             with psycopg2.connect(**params) as conn:
                 with conn.cursor() as cursor:


### PR DESCRIPTION
When I ran into the problems that prompted #10 and #9, I was caught off guard because this would appear to just hang endlessly. I think that `check_connection()` should time out much sooner.

If it's taking >> 10 seconds to connect to your testing db, something is almost certainly wrong.